### PR TITLE
feat: make selector polynomials optional

### DIFF
--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -100,7 +100,7 @@ where
                 let message_word = |i: usize| {
                     let value = self.message.map(|message_vals| message_vals[i]);
                     region.assign_advice(
-                        || format!("load message_{}", i),
+                        || format!("load message_{i}"),
                         config.input[i],
                         0,
                         || value,

--- a/halo2_gadgets/src/poseidon.rs
+++ b/halo2_gadgets/src/poseidon.rs
@@ -288,7 +288,7 @@ impl<
             .enumerate()
         {
             self.sponge
-                .absorb(layouter.namespace(|| format!("absorb_{}", i)), value)?;
+                .absorb(layouter.namespace(|| format!("absorb_{i}")), value)?;
         }
         self.sponge
             .finish_absorbing(layouter.namespace(|| "finish absorbing"))?

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -286,7 +286,7 @@ impl<
                 let mut state = Vec::with_capacity(WIDTH);
                 let mut load_state_word = |i: usize, value: F| -> Result<_, Error> {
                     let var = region.assign_advice_from_constant(
-                        || format!("state_{}", i),
+                        || format!("state_{i}"),
                         config.state[i],
                         0,
                         value,
@@ -325,7 +325,7 @@ impl<
                     initial_state[i]
                         .0
                         .copy_advice(
-                            || format!("load state_{}", i),
+                            || format!("load state_{i}"),
                             &mut region,
                             config.state[i],
                             0,
@@ -341,7 +341,7 @@ impl<
                     let constraint_var = match input.0[i].clone() {
                         Some(PaddedWord::Message(word)) => word,
                         Some(PaddedWord::Padding(padding_value)) => region.assign_fixed(
-                            || format!("load pad_{}", i),
+                            || format!("load pad_{i}"),
                             config.rc_b[i],
                             1,
                             || Value::known(padding_value),
@@ -350,7 +350,7 @@ impl<
                     };
                     constraint_var
                         .copy_advice(
-                            || format!("load input_{}", i),
+                            || format!("load input_{i}"),
                             &mut region,
                             config.state[i],
                             1,
@@ -370,7 +370,7 @@ impl<
                             .unwrap_or_else(|| Value::known(F::ZERO));
                     region
                         .assign_advice(
-                            || format!("load output_{}", i),
+                            || format!("load output_{i}"),
                             config.state[i],
                             2,
                             || value,
@@ -474,7 +474,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
             });
 
             region.assign_advice(
-                || format!("round_{} partial_sbox", round),
+                || format!("round_{round} partial_sbox"),
                 config.partial_sbox,
                 offset,
                 || r.as_ref().map(|r| r[0]),
@@ -536,7 +536,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
         let load_state_word = |i: usize| {
             initial_state[i]
                 .0
-                .copy_advice(|| format!("load state_{}", i), region, config.state[i], 0)
+                .copy_advice(|| format!("load state_{i}"), region, config.state[i], 0)
                 .map(StateWord)
         };
 
@@ -558,7 +558,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
         // Load the round constants.
         let mut load_round_constant = |i: usize| {
             region.assign_fixed(
-                || format!("round_{} rc_{}", round, i),
+                || format!("round_{round} rc_{i}"),
                 config.rc_a[i],
                 offset,
                 || Value::known(config.round_constants[round][i]),
@@ -574,7 +574,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
         let next_state_word = |i: usize| {
             let value = next_state[i];
             let var = region.assign_advice(
-                || format!("round_{} state_{}", next_round, i),
+                || format!("round_{next_round} state_{i}"),
                 config.state[i],
                 offset + 1,
                 || value,
@@ -649,7 +649,7 @@ mod tests {
                     let state_word = |i: usize| {
                         let value = Value::known(Fp::from(i as u64));
                         let var = region.assign_advice(
-                            || format!("load state_{}", i),
+                            || format!("load state_{i}"),
                             config.state[i],
                             0,
                             || value,
@@ -688,7 +688,7 @@ mod tests {
                 |mut region| {
                     let mut final_state_word = |i: usize| {
                         let var = region.assign_advice(
-                            || format!("load final_state_{}", i),
+                            || format!("load final_state_{i}"),
                             config.state[i],
                             0,
                             || Value::known(expected_final_state[i]),
@@ -774,7 +774,7 @@ mod tests {
                     let message_word = |i: usize| {
                         let value = self.message.map(|message_vals| message_vals[i]);
                         region.assign_advice(
-                            || format!("load message_{}", i),
+                            || format!("load message_{i}"),
                             config.state[i],
                             0,
                             || value,

--- a/halo2_gadgets/src/poseidon/primitives.rs
+++ b/halo2_gadgets/src/poseidon/primitives.rs
@@ -310,7 +310,7 @@ impl<F: PrimeField, const RATE: usize, const L: usize> Domain<F, RATE> for Const
     type Padding = iter::Take<iter::Repeat<F>>;
 
     fn name() -> String {
-        format!("ConstantLength<{}>", L)
+        format!("ConstantLength<{L}>")
     }
 
     fn initial_capacity_element() -> F {

--- a/halo2_proofs/benches/lookups.rs
+++ b/halo2_proofs/benches/lookups.rs
@@ -114,7 +114,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 |mut table| {
                     for row in 0u64..(1 << 8) {
                         table.assign_cell(
-                            || format!("row {}", row),
+                            || format!("row {row}"),
                             config.table,
                             row as usize,
                             || Value::known(F::from(row)),
@@ -131,7 +131,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     for offset in 0u64..(1 << 10) {
                         config.selector.enable(&mut region, offset as usize)?;
                         region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.advice,
                             offset as usize,
                             || Value::known(F::from(offset % 256)),
@@ -140,7 +140,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     for offset in 1u64..(1 << 10) {
                         config.selector.enable(&mut region, offset as usize)?;
                         region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.other_advice,
                             offset as usize - 1,
                             || Value::known(F::from(offset % 256)),

--- a/halo2_proofs/examples/simple-lookup-unblinded.rs
+++ b/halo2_proofs/examples/simple-lookup-unblinded.rs
@@ -100,7 +100,7 @@ fn main() {
 
                 let diff = lhs - rhs;
 
-                let constraint = diff.clone() * (Expression::Constant(F::ZERO) - diff.clone());
+                let constraint = diff.clone() * (Expression::Constant(F::ZERO) - diff);
 
                 Constraints::with_selector(s_mul, vec![constraint])
             });
@@ -118,14 +118,14 @@ fn main() {
                 |mut table| {
                     for row in 0u64..2_u64.pow(K - 1) {
                         table.assign_cell(
-                            || format!("input row {}", row),
+                            || format!("input row {row}"),
                             config.table_input,
                             row as usize,
                             || Value::known(F::from(row)),
                         )?;
                         // table output (2x the input) -- yeehaw
                         table.assign_cell(
-                            || format!("output row {}", row),
+                            || format!("output row {row}"),
                             config.table_output,
                             row as usize,
                             || Value::known(F::from(2 * row)),
@@ -144,14 +144,14 @@ fn main() {
                         config.qlookup.enable(&mut region, offset as usize)?;
                         // input
                         region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.advice,
                             offset as usize,
                             || Value::known(F::from(offset)),
                         )?;
                         // 2x
                         let cell = region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.other_advice,
                             offset as usize,
                             || Value::known(F::from(2 * offset)),
@@ -247,7 +247,7 @@ fn main() {
 
     env_logger::init();
 
-    println!("k = {}", K);
+    println!("k = {K}");
     // time it
     println!("keygen");
     let start = std::time::Instant::now();

--- a/halo2_proofs/examples/simple-lookup.rs
+++ b/halo2_proofs/examples/simple-lookup.rs
@@ -100,7 +100,7 @@ fn main() {
 
                 let diff = lhs - rhs;
 
-                let constraint = diff.clone() * (Expression::Constant(F::ZERO) - diff.clone());
+                let constraint = diff.clone() * (Expression::Constant(F::ZERO) - diff);
 
                 Constraints::with_selector(s_mul, vec![constraint])
             });
@@ -118,14 +118,14 @@ fn main() {
                 |mut table| {
                     for row in 0u64..2_u64.pow(K - 1) {
                         table.assign_cell(
-                            || format!("input row {}", row),
+                            || format!("input row {row}"),
                             config.table_input,
                             row as usize,
                             || Value::known(F::from(row)),
                         )?;
                         // table output (2x the input) -- yeehaw
                         table.assign_cell(
-                            || format!("output row {}", row),
+                            || format!("output row {row}"),
                             config.table_output,
                             row as usize,
                             || Value::known(F::from(2 * row)),
@@ -144,14 +144,14 @@ fn main() {
                         config.qlookup.enable(&mut region, offset as usize)?;
                         // input
                         region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.advice,
                             offset as usize,
                             || Value::known(F::from(offset)),
                         )?;
                         // 2x
                         let cell = region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.other_advice,
                             offset as usize,
                             || Value::known(F::from(2 * offset)),
@@ -247,7 +247,7 @@ fn main() {
 
     env_logger::init();
 
-    println!("k = {}", K);
+    println!("k = {K}");
     // time it
     println!("keygen");
     let start = std::time::Instant::now();

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -711,7 +711,7 @@ impl<F: FromUniformBytes<64> + Ord> MockProver<F> {
             )?;
         }
 
-        let (cs, selector_polys) = prover.cs.compress_selectors(prover.selectors.clone());
+        let (cs, selector_polys) = prover.cs.compress_selectors(prover.selectors.clone(), true);
         prover.cs = cs;
         prover.fixed.extend(selector_polys.into_iter().map(|poly| {
             let mut v = vec![CellValue::Unassigned; n];

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -283,7 +283,7 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
             cs.constants.clone(),
         )
         .unwrap();
-        let (cs, _) = cs.compress_selectors(layout.selectors);
+        let (cs, _) = cs.compress_selectors(layout.selectors, false);
 
         assert!((1 << k) >= cs.minimum_rows());
 

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -178,12 +178,12 @@ where
                     Ok(selector)
                 })
                 .collect::<io::Result<_>>()?;
-            let (cs, _) = cs.compress_selectors(selectors.clone());
+            let (cs, _) = cs.compress_selectors(selectors.clone(), false);
             (cs, selectors)
         } else {
             // we still need to replace selectors with fixed Expressions in `cs`
             let fake_selectors = vec![vec![]; cs.num_selectors];
-            let (cs, _) = cs.directly_convert_selectors_to_fixed(fake_selectors);
+            let (cs, _) = cs.directly_convert_selectors_to_fixed(fake_selectors, false);
             (cs, vec![])
         };
 

--- a/halo2_proofs/src/plonk/circuit/compress_selectors.rs
+++ b/halo2_proofs/src/plonk/circuit/compress_selectors.rs
@@ -183,7 +183,11 @@ where
         }
 
         // Now, compute the selector and combination assignments.
-        let mut combination_assignment = vec![F::ZERO; n];
+        let mut combination_assignment = if return_polys {
+            vec![F::ZERO; n]
+        } else {
+            vec![]
+        };
         let combination_len = combination.len();
         let combination_index = combination_assignments.len();
         let query = allocate_fixed_column();
@@ -207,6 +211,7 @@ where
             }
 
             // Update the combination assignment
+            // if return polys is false the iteration will not run as it is empty
             for (combination, selector) in combination_assignment
                 .iter_mut()
                 .zip(selector.activations.iter())
@@ -226,11 +231,8 @@ where
                 expression,
             }
         }));
-        if return_polys {
-            combination_assignments.push(combination_assignment);
-        } else {
-            combination_assignments.push(vec![]);
-        }
+        // if return polys is false this is empty
+        combination_assignments.push(combination_assignment);
     }
 
     (combination_assignments, selector_assignments)

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -265,11 +265,11 @@ where
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
     let (cs, selector_polys) = if compress_selectors {
-        cs.compress_selectors(assembly.selectors.clone())
+        cs.compress_selectors(assembly.selectors.clone(), true)
     } else {
         // After this, the ConstraintSystem should not have any selectors: `verify` does not need them, and `keygen_pk` regenerates `cs` from scratch anyways.
         let selectors = std::mem::take(&mut assembly.selectors);
-        cs.directly_convert_selectors_to_fixed(selectors)
+        cs.directly_convert_selectors_to_fixed(selectors, true)
     };
     fixed.extend(
         selector_polys
@@ -338,9 +338,9 @@ where
 
     let mut fixed = batch_invert_assigned(assembly.fixed);
     let (cs, selector_polys) = if vk.compress_selectors {
-        cs.compress_selectors(assembly.selectors)
+        cs.compress_selectors(assembly.selectors, true)
     } else {
-        cs.directly_convert_selectors_to_fixed(assembly.selectors)
+        cs.directly_convert_selectors_to_fixed(assembly.selectors, true)
     };
     fixed.extend(
         selector_polys


### PR DESCRIPTION
When compressing selectors, we make the calculation of the selector polys optional for verification so as to fit in low memory contexts (wasm etc...). 