### PR TITLE
Metal MSM GPU Acceleration Support

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -69,7 +69,7 @@ serde_derive = { version = "1", optional = true}
 bincode = { version = "1.3.3", default_features = false }
 serde = { version = "1.0.126", features = ["derive"] }
 instant = { version = "0.1" }
-
+mopro-msm = { git = "https://github.com/ElusAegis/metal-msm-gpu-acceleration.git", rev = "962e4d", optional = true, features = ["h2c"], default-features = false }
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", default-features = false, optional = true }
@@ -107,6 +107,8 @@ batch = ["rand_core/getrandom"]
 circuit-params = []
 counter = []
 icicle_gpu = ["icicle", "rustacuda"]
+macos = ["mopro-msm/macos"]
+ios = ["mopro-msm/ios"]
 mv-lookup = []
 cost-estimator = ["serde_derive"]
 derive_serde = ["halo2curves/derive_serde"]


### PR DESCRIPTION
This PR introduces support for Metal-based MSM GPU acceleration, leveraging the [mopro GPU acceleration fork](https://github.com/ElusAegis/metal-msm-gpu-acceleration).

### Key Highlights:
- **Performance Gains**: 
  - Expected performance improvements of approximately **25% for log 17** instance sizes.
  - Gains increase to **35% or more for log 20+** instance sizes.
  - Detailed benchmarking results are available in the [mopro GPU acceleration fork](https://github.com/ElusAegis/metal-msm-gpu-acceleration).

- **Selective Activation**:
  - The GPU acceleration is feature gated and further will only be enabled **only for MSM operations** with an instance size of **log 17 or greater**.
  - A user warning is displayed to inform about the activation threshold and expected benefits.

### Notes:
This enhancement provides a significant boost for large-scale MSM computations, by collectively utilizing Metal's GPU resources with CPU resources on supported devices.