### PR TITLE
Optimize CPU Algorithm for Halo2 Multi-Open Proof

### DIFF
--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -16,6 +16,10 @@ use group::{
 use halo2curves::msm::msm_best;
 pub use halo2curves::{CurveAffine, CurveExt};
 
+use maybe_rayon::iter::ParallelIterator;
+use maybe_rayon::prelude::ParallelSliceMut;
+use maybe_rayon::iter::IndexedParallelIterator;
+
 /// This represents an element of a group with basic operations that can be
 /// performed. This allows an FFT implementation (for example) to operate
 /// generically over either a field or elliptic curve group.
@@ -201,6 +205,57 @@ pub fn compute_inner_product<F: Field>(a: &[F], b: &[F]) -> F {
     acc
 }
 
+/// Performs element-wise addition of vector `b` multiplied by scalar `k` to vector `a`.
+/// This function executes in parallel to improve performance.
+fn vector_add_mul_scalar_inplace<F: Field>(a: &mut Vec<F>, b: &Vec<F>, k: F)
+{
+    parallelize(a, |lhs, start| {
+        for (lhs, rhs) in lhs
+            .iter_mut()
+            .zip(b[start..].iter())
+        {
+            *lhs += (*rhs) *k;
+        }
+    });
+}
+
+/// Multiplies each element of vector `a` by scalar `k` in place.
+/// This function executes in parallel to enhance performance.
+pub fn vector_mul_scalar_inplace<F: Field>(a: &mut Vec<F>, k: F)
+{
+    parallelize(a, |lhs, _| {
+        for lh in lhs
+                    .iter_mut()
+        {
+            *lh *= k;
+        }
+    });
+}
+
+/// Computes the first `n` powers of the element `b`.
+/// /// This function utilizes parallel computation to optimize the power calculations.
+pub fn compute_powers<F: Field>(b: F, n: usize) -> Vec<F>{
+
+    let num_threads = multicore::current_num_threads();
+    let chunk_size = (n + num_threads-1)/ num_threads;
+    let mut pows = vec!(F::ZERO; n);
+
+    pows.par_chunks_mut(chunk_size)
+        .enumerate()
+        .for_each(|(cid, pows)| {
+
+            let start = cid * chunk_size;
+            let mut prvb  = b.pow_vartime([start as u64, 0, 0, 0]);
+
+            for pow in pows.iter_mut() {
+                *pow  = prvb;
+                prvb *= b;
+            }
+    });
+
+    pows
+}
+
 /// Divides polynomial `a` in `X` by `X - b` with
 /// no remainder.
 pub fn kate_division<'a, F: Field, I: IntoIterator<Item = &'a F>>(a: I, mut b: F) -> Vec<F>
@@ -219,6 +274,175 @@ where
         *q = lead_coeff;
         tmp = lead_coeff;
         tmp.mul_assign(&b);
+    }
+
+    q
+}
+
+/// Divides polynomial `a` in `X` by `X - b` with
+/// no remainder.
+pub fn kate_division_par<F: Field>(poly: &[F], b: F) -> Vec<F>
+{
+    fn poly_div<F: Field>(a: &[F], b: F, q: &mut [F], remd: &mut F) {
+        let b_neg = -b;
+
+        let mut tmp = F::ZERO;
+        for i in (0..a.len()-1).rev() {
+
+            let r = a[i+1];
+            let mut lead_coeff = r;
+            lead_coeff.sub_assign(&tmp);
+
+            q[i] = lead_coeff;
+            tmp = lead_coeff;
+            tmp.mul_assign(&b_neg);
+        }
+
+        *remd = a[0] - tmp;
+    }
+
+    let n = poly.len();
+    let num_threads  = multicore::current_num_threads(); // n*2; // multicore::current_num_threads();
+    let mut quotient = vec![F::ZERO; n];
+    let mut remaindr = vec![F::ZERO; num_threads];
+
+
+    if n < num_threads {
+        poly_div(&poly[0..n], b, &mut quotient, &mut remaindr[0]);
+    }
+
+
+    else
+    {
+        let start = instant::Instant::now();
+        let chunk_size = (n + num_threads - 1) / num_threads;
+
+
+        multicore::scope(|scope| {
+            for (chunk_idx, (r, mut q)) in remaindr
+                                        .chunks_mut(1)
+                                        .zip(quotient.chunks_mut(chunk_size))
+                                        .enumerate()
+            {
+                scope.spawn(move |_| {
+                    let start = chunk_idx * chunk_size;
+                    let max   = start + chunk_size;
+                    let end   = if max<n {max} else {n};
+
+                    poly_div(&poly[start..end], b, &mut q, &mut r[0]);
+                });
+            }
+        });
+        /*---------------------------------------------------
+         let n = num_threads = 2, c = chunk_size
+         quotient[0] = 0, 1, ..., c-2   ; remainders[0] = 0;
+         quotient[1] = c + (0, ..., c-2); remainders[1] = c;
+
+         poly     = 0, 1, ..., 2c - 1
+         quotient = 0, 1, ..., 2c - 2
+         ----------------------------------------------------*/
+        let comp_div_poly_t = start.elapsed();
+
+
+        let start = instant::Instant::now();
+
+        let mut bpows = compute_powers(b, chunk_size)[0..chunk_size].to_vec();
+        bpows.reverse();
+
+        for tid in (0..num_threads-1).rev() {
+            let r = remaindr[tid+1];
+            remaindr[tid] += r*bpows[0]*b;
+        }
+
+        let pows_of_b_t = start.elapsed();
+
+
+        let start = instant::Instant::now();
+
+        quotient.par_chunks_mut(chunk_size)
+                .enumerate()
+                .take(num_threads - 1)
+                .for_each(|(tid, qs)| {
+
+                    let r = remaindr[tid+1];
+                    for (i, q) in qs.iter_mut().enumerate() {
+
+                        let pow = bpows[i];
+                        *q = *q + (pow*r);
+                    }
+
+                });
+
+        for tid in 1..num_threads {
+            quotient[tid*chunk_size-1] = remaindr[tid];
+        }
+        let vec_sub_t = start.elapsed();
+
+
+        // println!("kate_division_par comp_div_poly_t: {:?}, pows_of_b_t: {:?}, vec_sub_t: {:?}, chunk_size: {chunk_size}.",
+        //           comp_div_poly_t, pows_of_b_t, vec_sub_t, );
+    };
+
+
+    quotient[0..n-1].to_vec()
+}
+
+/// Divides polynomial `a` in `X` by `(X - b0) (X - b1)` with
+/// no remainder.
+pub fn kate_division_deg2<'a, F: Field, I: IntoIterator<Item = &'a F>>(a: I, b: &[F]) -> Vec<F>
+where
+    I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+{
+    let (b1,b2) = (b[0],b[1]);
+    let a = a.into_iter();
+
+    let mut q = vec![F::ZERO; a.len() - b.len()];
+    let mut prv1 = F::ZERO;
+    let mut prv2 = F::ZERO;
+
+    for (q, r) in q.iter_mut().rev().zip(a.rev()) {
+        let mut lead_coeff = *r;
+
+        lead_coeff.add_assign(&(prv2 * b2));
+        prv2 = lead_coeff;
+
+        lead_coeff.add_assign(&prv1);
+        *q = lead_coeff;
+
+        prv1 = lead_coeff * b1;
+    }
+
+    q
+}
+
+/// Divides polynomial `a` in `X` by `(X - b0) (X - b1) (X - b2)` with
+/// no remainder.
+pub fn kate_division_deg3<'a, F: Field, I: IntoIterator<Item = &'a F>>(a: I, b: &[F]) -> Vec<F>
+where
+    I::IntoIter: DoubleEndedIterator + ExactSizeIterator,
+{
+    let (b1,b2,b3) = (b[0],b[1],b[2]);
+    let a = a.into_iter();
+
+    let mut q = vec![F::ZERO; a.len() - b.len()];
+    let mut prv1 = F::ZERO;
+    let mut prv2 = F::ZERO;
+    let mut prv3 = F::ZERO;
+    let mut prvq = F::ZERO;
+
+    for (q, r) in q.iter_mut().rev().zip(a.rev()) {
+        let mut lead_coeff = *r;
+
+        lead_coeff.add_assign(&(prv3 * b3));
+        prv3 = lead_coeff;
+
+        lead_coeff.add_assign(&prv1);
+        lead_coeff.add_assign(&((prvq - prv2) * b2));
+        *q = lead_coeff;
+
+        prv2 = prv1;
+        prv1 = lead_coeff * b1;
+        prvq = lead_coeff;
     }
 
     q
@@ -369,6 +593,17 @@ pub(crate) fn evaluate_vanishing_polynomial<F: Field>(roots: &[F], z: F) -> F {
 
 pub(crate) fn powers<F: Field>(base: F) -> impl Iterator<Item = F> {
     std::iter::successors(Some(F::ONE), move |power| Some(base * power))
+}
+
+pub(crate) fn powers_of_x<F: Field>(base: F, n: usize) -> Vec<F> {
+
+    let mut pows = Vec::<F>::with_capacity(n);
+
+    pows.push(F::ONE);
+    for i in 1..n {
+        pows.push(pows[i-1]*base);
+    }
+    pows
 }
 
 /// Reverse `l` LSBs of bitvector `n`

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -320,6 +320,85 @@ impl<F: Field> Polynomial<F, LagrangeCoeff> {
     }
 }
 
+impl<F: Field, B: Basis> Polynomial<F, B> {
+    ///
+    pub fn add_mul_scalar(&mut self, poly: &Self, k: F) {
+        parallelize(&mut self.values, |lhs, start| {
+            for (lhs, rhs) in lhs
+                .iter_mut()
+                .zip(poly.values[start..].iter())
+            {
+                *lhs += (*rhs) *k;
+            }
+        });
+    }
+
+    ///
+    pub fn add_mul_scalars(&mut self, polys: &[&Self], k: &[F]) {
+        let poly_num = polys.len();
+
+        parallelize(&mut self.values, |lhs, start| {
+            let mut i = start;
+            for lhs in lhs.iter_mut()
+            {
+                for j in 0..poly_num {
+                    *lhs += polys[j].values[i] * k[j];
+                }
+
+                i += 1;
+            }
+        });
+    }
+
+    ///
+    pub fn add_inplace(&mut self, poly: &Self) {
+        parallelize(&mut self.values, |lhs, start| {
+            for (lhs, rhs) in lhs
+                .iter_mut()
+                .zip(poly.values[start..].iter())
+            {
+                *lhs += *rhs;
+            }
+        });
+    }
+
+    ///
+    pub fn mul_inplace_scalar(&mut self, k: F) {
+        parallelize(&mut self.values, |lhs, start| {
+            for lh in lhs
+                .iter_mut()
+            {
+                *lh *= k;
+            }
+        });
+    }
+
+    ///
+    pub fn sub_low_poly_mul_scalar(&mut self, poly: &Self, k: F) {
+
+        let len = poly.len();
+        let thr = 1000;
+
+        if len>thr {
+            parallelize(&mut self.values[0..len], |lhs, start| {
+                for (lhs, rhs) in lhs
+                                    .iter_mut()
+                                    .zip(poly.values[start..].iter()) {
+                    *lhs -= (*rhs) * k;
+                }
+            });
+        }
+
+        else {
+            for (lhs, rhs) in self.values[0..len]
+                                    .iter_mut()
+                                    .zip(poly.values[..].iter()) {
+                                        *lhs -= (*rhs) * k;
+            }
+        }
+    }
+}
+
 impl<F: Field, B: Basis> Mul<F> for Polynomial<F, B> {
     type Output = Polynomial<F, B>;
 

--- a/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
+++ b/halo2_proofs/src/poly/kzg/multiopen/shplonk/prover.rs
@@ -3,6 +3,7 @@ use super::{
 };
 use crate::arithmetic::{
     eval_polynomial, evaluate_vanishing_polynomial, kate_division, lagrange_interpolate,
+    kate_division_deg2, kate_division_deg3, kate_division_par, vector_mul_scalar_inplace, powers_of_x,
     parallelize, powers, CurveAffine,
 };
 use crate::helpers::SerdeCurveAffine;
@@ -23,12 +24,21 @@ use std::fmt::Debug;
 use std::io;
 use std::marker::PhantomData;
 use std::ops::MulAssign;
+use std::hash::Hash;
+use maybe_rayon::iter::IndexedParallelIterator;
 
 fn div_by_vanishing<F: Field>(poly: Polynomial<F, Coeff>, roots: &[F]) -> Vec<F> {
     let poly = roots
         .iter()
         .fold(poly.values, |poly, point| kate_division(&poly, *point));
 
+    poly
+}
+
+fn div_by_vanishing_par<F: Field>(poly: Polynomial<F, Coeff>, roots: &[F]) -> Vec<F> {
+    let poly = roots
+        .iter()
+        .fold(poly.values, |poly, point| kate_division_par(&poly, *point));
     poly
 }
 
@@ -106,7 +116,7 @@ impl<'a, E: Engine> ProverSHPLONK<'a, E> {
 impl<'params, E: Engine + Debug> Prover<'params, KZGCommitmentScheme<E>>
     for ProverSHPLONK<'params, E>
 where
-    E::Fr: Ord,
+    E::Fr: Ord + Hash,
     E::G1Affine: SerdeCurveAffine<ScalarExt = <E as Engine>::Fr, CurveExt = <E as Engine>::G1>,
     E::G1: CurveExt<AffineExt = E::G1Affine>,
     E::G2Affine: SerdeCurveAffine,
@@ -138,40 +148,72 @@ where
         // for different sets that are already combined with another challenge
         let y: ChallengeY<_> = transcript.squeeze_challenge_scalar();
 
-        let quotient_contribution = |rotation_set: &RotationSetExtension<E::G1Affine>| {
+        let quotient_contribution = |i: usize, rotation_set: &RotationSetExtension<E::G1Affine>| {
             // [P_i_0(X) - R_i_0(X), P_i_1(X) - R_i_1(X), ... ]
-            #[allow(clippy::needless_collect)]
-            let numerators = rotation_set
-                .commitments
-                .as_slice()
-                .into_par_iter()
-                .map(|commitment| commitment.quotient_contribution())
-                .collect::<Vec<_>>();
+
+            // #[allow(clippy::needless_collect)]
+            // let numerators = rotation_set
+            //     .commitments
+            //     .as_slice()
+            //     .into_par_iter()
+            //     .map(|commitment| commitment.quotient_contribution())
+            //     .collect::<Vec<_>>();
 
             // define numerator polynomial as
             // N_i_j(X) = (P_i_j(X) - R_i_j(X))
             // and combine polynomials with same evaluation point set
             // N_i(X) = linear_combination(y, N_i_j(X))
             // where y is random scalar to combine numerator polynomials
-            let n_x = numerators
-                .into_iter()
-                .zip(powers(*y))
-                .map(|(numerator, power_of_y)| numerator * power_of_y)
-                .reduce(|acc, numerator| acc + &numerator)
-                .unwrap();
+
+            let poly_num = rotation_set.commitments.len();
+            let ys  = powers_of_x(*y, poly_num);
+
+            let start = instant::Instant::now();
+            let mut comb_poly = rotation_set
+                                      .commitments[0].commitment.get().poly.clone();
+            let mut_comb_poly = &mut comb_poly;
+
+            let polys: Vec<_> = rotation_set
+                                      .commitments[1..poly_num]
+                                      .iter()
+                                      .map(|cmmt| cmmt.commitment.get().poly)
+                                      .collect();
+            mut_comb_poly.add_mul_scalars(&polys, &ys[1..poly_num]);
+            let cmmt_poly_comb_t = start.elapsed();
+
+            let start = instant::Instant::now();
+            let mut n_x = comb_poly.clone();
+            let mut_nx  = &mut n_x;
+
+            for i in 0..poly_num {
+                let cmmt = &rotation_set.commitments[i];
+                let poly = &cmmt.low_degree_equivalent;
+                mut_nx.sub_low_poly_mul_scalar(poly, ys[i]);
+            };
+            let nx_sub_low_poly_t = start.elapsed();
 
             let points = &rotation_set.points[..];
 
             // quotient contribution of this evaluation set is
             // Q_i(X) = N_i(X) / Z_i(X) where
             // Z_i(X) = (x - r_i_0) * (x - r_i_1) * ...
-            let mut poly = div_by_vanishing(n_x, points);
-            poly.resize(self.params.n as usize, E::Fr::ZERO);
 
-            Polynomial {
+            let start = instant::Instant::now();
+            let mut poly = match points.len() {
+                2 => kate_division_deg2(&n_x.values, points),
+                3 => kate_division_deg3(&n_x.values, points),
+                _ => div_by_vanishing(n_x, points),
+            };
+
+            poly.resize(self.params.n as usize, E::Fr::ZERO);
+            let nx_div_vanish_t = start.elapsed();
+
+            let quot_poly = Polynomial {
                 values: poly,
-                _marker: PhantomData,
-            }
+                _marker: PhantomData, };
+
+            ((i,comb_poly), quot_poly)
+
         };
 
         let intermediate_sets = construct_intermediate_sets(queries);
@@ -195,25 +237,35 @@ where
 
         let v: ChallengeV<_> = transcript.squeeze_challenge_scalar();
 
-        #[allow(clippy::needless_collect)]
-        let quotient_polynomials = rotation_sets
-            .as_slice()
-            .into_par_iter()
-            .map(quotient_contribution)
-            .collect::<Vec<_>>();
+        let start = instant::Instant::now();
 
-        let h_x: Polynomial<E::Fr, Coeff> = quotient_polynomials
-            .into_iter()
-            .zip(powers(*v))
-            .map(|(poly, power_of_v)| poly * power_of_v)
-            .reduce(|acc, poly| acc + &poly)
-            .unwrap();
+        #[allow(clippy::needless_collect)]
+        let (comb_polys, quotient_polynomials): (
+            Vec<(usize, Polynomial<E::Fr, Coeff>)>,
+            Vec<Polynomial<E::Fr, Coeff>>,
+        ) = rotation_sets
+                    .as_slice()
+                    .into_par_iter()
+                    .enumerate()
+                    .map(|(i, rotation_set)| quotient_contribution(i, rotation_set))
+                    .unzip();
+        let quot_polys_t = start.elapsed();
+
+        let start = instant::Instant::now();
+        let vs  = powers_of_x(*v, quotient_polynomials.len());
+
+        let mut h_x = quotient_polynomials[0].clone();
+        let polynomials_refs: Vec<&Polynomial<E::Fr, Coeff>> = quotient_polynomials[1..].iter().collect();
+        &h_x.add_mul_scalars(&polynomials_refs, &vs[1..quotient_polynomials.len()]);
+
+        let quot_polys_comb_t = start.elapsed();
+
 
         let h = self.params.commit(&h_x, Blind::default()).to_affine();
         transcript.write_point(h)?;
         let u: ChallengeU<_> = transcript.squeeze_challenge_scalar();
 
-        let linearisation_contribution = |rotation_set: RotationSetExtension<E::G1Affine>| {
+        let linearisation_contribution = |i: usize, rotation_set: RotationSetExtension<E::G1Affine>| {
             let mut diffs = super_point_set.clone();
             for point in rotation_set.points.iter() {
                 diffs.remove(point);
@@ -227,29 +279,43 @@ where
             // [P_i_0(X) - r_i_0, P_i_1(X) - r_i_1, ... ] where
             // r_i_j = R_i_j(u) is the evaluation of low degree equivalent polynomial
             // where u is random evaluation point
-            #[allow(clippy::needless_collect)]
-            let inner_contributions = rotation_set
-                .commitments
-                .as_slice()
-                .into_par_iter()
-                .map(|commitment| commitment.linearisation_contribution(*u))
-                .collect::<Vec<_>>();
+
+            let low_poly_vals = rotation_set.commitments
+                                            .as_slice()
+                                            .into_iter()
+                                            .map(|cmmt| eval_polynomial(&cmmt.low_degree_equivalent.values[..], *u))
+                                            .collect::<Vec<_>>();
+
+            let num = rotation_set.commitments.len();
+            let ys  = powers_of_x(*y, num);
+
+            let mut l_x  = comb_polys.iter()
+                                     .find(|(j, _)| *j == i)
+                                     .map(|(_, poly)| poly)
+                                     .expect("none sense")
+                                     .clone();
+            let mut_lx = &mut l_x;
+
+            for i in 0..num {
+                let poly  = Polynomial {
+                                values: [low_poly_vals[i]].to_vec(),
+                                _marker: PhantomData,
+                            };
+                mut_lx.sub_low_poly_mul_scalar(&poly, ys[i]);
+            };
 
             // define inner contributor polynomial as
             // L_i_j(X) = (P_i_j(X) - r_i_j)
             // and combine polynomials with same evaluation point set
             // L_i(X) = linear_combination(y, L_i_j(X))
             // where y is random scalar to combine inner contributors
-            let l_x: Polynomial<E::Fr, Coeff> = inner_contributions
-                .into_iter()
-                .zip(powers(*y))
-                .map(|(poly, power_of_y)| poly * power_of_y)
-                .reduce(|acc, poly| acc + &poly)
-                .unwrap();
 
             // finally scale l_x by difference vanishing polynomial evaluation z_i
             (l_x * z_i, z_i)
         };
+
+
+        let start = instant::Instant::now();
 
         #[allow(clippy::type_complexity)]
         let (linearisation_contributions, z_diffs): (
@@ -257,15 +323,18 @@ where
             Vec<E::Fr>,
         ) = rotation_sets
             .into_par_iter()
-            .map(linearisation_contribution)
+            .enumerate()
+            .map(|(i, rotation_set)| linearisation_contribution(i, rotation_set))
             .unzip();
+        let lin_contris_t = start.elapsed();
 
-        let l_x: Polynomial<E::Fr, Coeff> = linearisation_contributions
-            .into_iter()
-            .zip(powers(*v))
-            .map(|(poly, power_of_v)| poly * power_of_v)
-            .reduce(|acc, poly| acc + &poly)
-            .unwrap();
+        let start = instant::Instant::now();
+        let mut l_x = linearisation_contributions[0].clone();// * vs[linearisation_contributions.len()];
+        let polynomials_refs: Vec<&Polynomial<E::Fr, Coeff>> = linearisation_contributions[1..].iter().collect();
+
+        &l_x.add_mul_scalars(&polynomials_refs, &vs[1..]);
+        let lin_contri_comb_t = start.elapsed();
+
 
         let super_point_set = super_point_set.into_iter().collect::<Vec<_>>();
         let zt_eval = evaluate_vanishing_polynomial(&super_point_set[..], *u);
@@ -278,13 +347,12 @@ where
             assert_eq!(must_be_zero, E::Fr::ZERO);
         }
 
-        let mut h_x = div_by_vanishing(l_x, &[*u]);
+        let mut h_x = div_by_vanishing_par(l_x, &[*u]);
 
         // normalize coefficients by the coefficient of the first polynomial
         let z_0_diff_inv = z_diffs[0].invert().unwrap();
-        for h_i in h_x.iter_mut() {
-            h_i.mul_assign(z_0_diff_inv)
-        }
+
+        vector_mul_scalar_inplace(&mut h_x, z_0_diff_inv);
 
         let h_x = Polynomial {
             values: h_x,


### PR DESCRIPTION


## Overview
This PR implements optimizations to the CPU algorithm for the Halo2 multi-open proof, featuring:

- **Calculation of quotient and linearization polynomials** ✨
- **A new algorithm for random linear combinations of polynomials** 🔍
- **A parallel `div_by_vanishing` function** ⚡

We found that the current implementation of the Halo2 multi-open proof incurs unnecessary large memory allocations and redundant computations. By applying straightforward mathematical reasoning, we modified the computational process to avoid these inefficiencies, resulting in approximately a **10% reduction** in proof time ⏱️.

## Previous Computational Process
1. **Quotient Contribution Calculation**
    ```plaintext
    numerators_poly_i = poly_i - low_degree_equivalent_i  // for i = 0, ..., n
    numerator_poly = r^0 * numerators_poly_0 + ... + r^n * numerators_poly_n  // r is the random challenge value
    quotient_poly = numerator_poly / vanish_poly
    ```

2. **Linearization Contribution**
    ```plaintext
    inner_contributions_i = poly_i - r_i  // r_i = low_degree_equivalent_i(u) is the evaluation of the low degree equivalent polynomial
                                             // where u is the random evaluation point
    l_x = r^0 * inner_contributions_0 + ... + r^n * inner_contributions_n  // r is the random challenge value
    ```

## Revised Computational Process
1. **Quotient Contribution Calculation**
    ```plaintext
    combine_poly = r^0 * poly_0 + ... + r^n * poly_n
    numerator_poly = combine_poly - (r^0 * low_degree_equivalent_0 + ... + r^n * low_degree_equivalent_n)
    quotient_poly = numerator_poly / vanish_poly
    ```

2. **Linearization Contribution**
    ```plaintext
    l_x = combine_poly - (r^0 * r_i + ... + r^n * r_i)
    ```

## Optimization Insights
- The revised quotient contribution calculation eliminates the creation of **n** new polynomials, which typically consume significant memory 💾.
- The linearization contribution now reuses the previously computed **combine_poly**, avoiding redundant calculations 🔄.

These changes lead to improved memory efficiency and overall performance of the proof process, contributing to a more streamlined implementation of the Halo2 multi-open proof. 🚀



