### PR TITLE
halo2_proofs: drop stale #![feature(int_roundings)] gate

### DIFF
--- a/halo2_proofs/src/lib.rs
+++ b/halo2_proofs/src/lib.rs
@@ -13,7 +13,6 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
-#![feature(int_roundings)]
 
 #[cfg(feature = "counter")]
 #[macro_use]


### PR DESCRIPTION
## Summary

`int_roundings` was stabilized in Rust 1.73 (October 2023), so the underlying
methods (`div_ceil`, `next_multiple_of`, etc.) are available on stable. The
`#![feature(int_roundings)]` declaration in `halo2_proofs/src/lib.rs` is now
a no-op on a current nightly toolchain and a hard build error on stable.

Removing the gate has no behavioral effect on nightly users and unblocks
downstream consumers building on stable Rust.

## Motivation

I'm a downstream consumer using `zkonduit/halo2` indirectly (via ezkl) inside
a Substrate-based chain that needs to verify ezkl-produced proofs in a
node-binary host function. Substrate's official guidance is to build node
binaries on stable Rust, and `int_roundings` is the only blocker preventing
the zkonduit halo2 fork from compiling on stable today.

I tested the change against rustc 1.94.1 (stable) — `halo2_proofs` and the
downstream `zkonduit/snark-verifier` build cleanly with `mv-lookup` and
`circuit-params` features enabled. No semantic change.

If you'd prefer not to merge this directly into `main`, a maintained branch
that tracks the same code without the gate would also be useful. Happy to
adjust the patch or rebase onto `ac/conditional-compilation-icicle2` if that
is the more active development line.

Thanks for maintaining this fork — ezkl's whole proving flow rests on it.